### PR TITLE
fix to execute docker compose up --build in a  reasonable time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ env/
 system_module_1/__pycache__/
 cli/__pycache__/
 system_module_1/data/
+system_module_1/discarded_*.csv
 
 # === Java / Maven ===
 HELP.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,8 @@ services:
       DB_HOST: mysql
       DB_PORT: 3306
       DB_NAME: imdb_db
-      MYSQL_USER: imdbDockerDeploy
-      MYSQL_PASSWORD: imdbDockerDeploy
+      DB_USER: imdbDockerDeploy
+      DB_PASSWORD: imdbDockerDeploy
     command: ["python", "main.py", "reload"]
 
   system_module_2:
@@ -48,8 +48,8 @@ services:
       DB_HOST: mysql
       DB_PORT: 3306
       DB_NAME: imdb_db
-      MYSQL_USER: imdbDockerDeploy
-      MYSQL_PASSWORD: imdbDockerDeploy
+      DB_USER: imdbDockerDeploy
+      DB_PASSWORD: imdbDockerDeploy
     ports:
       - "8080:8080"
 

--- a/system_module_1/.dockerignore
+++ b/system_module_1/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.gz
+*.zip
+*.csv
+*.tsv
+*.log
+data/imdb_downloads/
+discarded_people_*.csv


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

Executing `docker compose up --build` was taking so much time. It was solved by avoiding to copy to image some unnecessary files.

<!-- Briefly describe what this PR is solving or implementing -->

## 🧩 Type of Change

<!-- Mark with "x" where applicable -->
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Major change that requires documentation update

## ✅ Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass locally
- [x] I’ve updated documentation if applicable
- [x] No unnecessary commented code remains
- [ ] I’ve updated the CHANGELOG

## 🧪 How was this tested?

<!-- Describe testing steps: manual, unit tests, integration, etc. -->

## 🔗 Related Issues

Closes #...

## 📸 Screenshots (optional)

<!-- Add screenshots if relevant -->
